### PR TITLE
fix: parser, show errors correctly!!

### DIFF
--- a/.freeCodeCamp/tests/parser.test.js
+++ b/.freeCodeCamp/tests/parser.test.js
@@ -43,7 +43,7 @@ try {
   assert.equal(lessonHintsAndTests[0][0], 'Test text with many words.');
   assert.equal(
     lessonHintsAndTests[0][1],
-    "// First test code\nconst a = 'test';"
+    "// First test code\nconst a = 'test';\n"
   );
   assert.equal(
     lessonHintsAndTests[1][0],
@@ -51,16 +51,16 @@ try {
   );
   assert.equal(
     lessonHintsAndTests[1][1],
-    "const a = 'test2';\n// Second test code;"
+    "const a = 'test2';\n// Second test code;\n"
   );
 
   const lessonSeed = getLessonSeed(lesson);
 
   const beforeAll = getBeforeAll(lesson);
-  assert.equal(beforeAll, "global.__beforeAll = 'before-all';\n\n");
+  assert.equal(beforeAll, "global.__beforeAll = 'before-all';\n\n\n");
 
   const beforeEach = getBeforeEach(lesson);
-  assert.equal(beforeEach, "global.__beforeEach = 'before-each';");
+  assert.equal(beforeEach, "global.__beforeEach = 'before-each';\n");
 
   const commands = getCommands(lessonSeed);
 
@@ -94,7 +94,7 @@ try {
   assert.equal(lessonHintsAndTests[0][0], 'Test text at top.');
   assert.equal(
     lessonHintsAndTests[0][1],
-    '// First test no space\n// No code?\n'
+    '// First test no space\n// No code?\n\n'
   );
   assert.equal(
     lessonHintsAndTests[1][0],
@@ -102,13 +102,13 @@ try {
   );
   assert.equal(
     lessonHintsAndTests[1][1],
-    "// Too many spaces?\nconst a = 'test2';"
+    "// Too many spaces?\nconst a = 'test2';\n"
   );
 
   const lessonSeed = getLessonSeed(lesson);
 
   const beforeAll = getBeforeAll(lesson);
-  assert.equal(beforeAll, "global.__beforeAll = 'before-all';");
+  assert.equal(beforeAll, "global.__beforeAll = 'before-all';\n");
 
   const beforeEach = getBeforeEach(lesson);
 
@@ -125,13 +125,13 @@ try {
   let stringFromCode = extractStringFromCode(`\`\`\`js
 const a = 1;
 \`\`\``);
-  assert.equal(stringFromCode, 'const a = 1;');
+  assert.equal(stringFromCode, 'const a = 1;\n');
   stringFromCode = extractStringFromCode(`\`\`\`js
 const a = 1;
 // comment
 \`\`\`
 `);
-  assert.equal(stringFromCode, 'const a = 1;\n// comment\n');
+  assert.equal(stringFromCode, 'const a = 1;\n// comment\n\n');
 } catch (e) {
   throw error(e);
 }

--- a/.freeCodeCamp/tooling/parser.js
+++ b/.freeCodeCamp/tooling/parser.js
@@ -70,7 +70,7 @@ export function getLessonHintsAndTests(lesson) {
   const testsString = lesson.trim().split(new RegExp(NEXT_MARKER))?.[2];
   const hintsAndTestsArr = [];
   const hints = testsString?.match(/^(.*?)$(?=\n+```js)/gm).filter(Boolean);
-  const tests = testsString.match(/(?<=```js\n).*?(?=\n```)/gms);
+  const tests = testsString.match(/(?<=```js\n).*?(?=```)/gms);
 
   if (hints?.length) {
     for (let i = 0; i < hints.length; i++) {
@@ -164,5 +164,5 @@ export function isForceFlag(seed) {
  * @returns {string} The stripped codeblock
  */
 export function extractStringFromCode(code) {
-  return code.replace(/.*?```[a-z]+\n(.*?)\n```/s, '$1');
+  return code.replace(/.*?```[a-z]+\n(.*?)```/s, '$1');
 }

--- a/.freeCodeCamp/tooling/test.js
+++ b/.freeCodeCamp/tooling/test.js
@@ -23,7 +23,7 @@ import {
 import logover, { error, warn, debug, info } from 'logover';
 import { join } from 'path';
 logover({
-  level: process.env.NODE_ENV === 'production' ? 'warn' : 'debug'
+  level: process.env.NODE_ENV === 'production' ? 'info' : 'debug'
 });
 
 export default async function runTests(ws, project) {
@@ -81,8 +81,8 @@ export default async function runTests(ws, project) {
           testId: i
         });
       } catch (e) {
-        if (!e instanceof AssertionError) {
-          warn(e);
+        if (!(e instanceof AssertionError)) {
+          error(e);
         }
         const consoleError = `<details>\n<summary>${
           i + 1


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #22

The reason this was so bad to work with is this line:

```diff
- if (!e instanceof AssertionError) {
+ if (!(e instanceof AssertionError)) {
  error(e);
}
```