### PR TITLE
Fix Response Headers to pass the tests

### DIFF
--- a/build-a-web3-client-side-package-for-your-dapp/node/provider.js
+++ b/build-a-web3-client-side-package-for-your-dapp/node/provider.js
@@ -31,6 +31,7 @@ app.post('/call-smart-contract', async (req, res) => {
 
   try {
     const result = await callSmartContract(id, method, args, address);
+    res.contentType('application/json');
     res.json({ result });
   } catch (e) {
     logover.error(e);
@@ -53,6 +54,7 @@ app.post('/get-balance', async (req, res) => {
   if (!balance) {
     return res.status(404).json({ error: 'Account not found' });
   }
+  res.contentType('application/json');
   return res.json({ result: balance });
 });
 
@@ -68,6 +70,7 @@ app.post('/transfer', async (req, res) => {
   }
   try {
     await transfer({ from, to, amount });
+    res.contentType('application/json');
     res.json({ result: 'success' });
   } catch (e) {
     logover.error(e);


### PR DESCRIPTION
There is a test for each of the three post requests (contract call, get balance, transfer) which expects 'Content-Type' to be 'application/json' on the response header. (The test description is misleading though, because is refers to the **request** header while the fail results from a check on the **response** header)

The issue comes from Express automatically adding 'charset=UTF-8'.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
