### PR TITLE
fix: Test8 in marketplace tutorial runs in the correct folder

### DIFF
--- a/curriculum/locales/english/build-a-video-game-marketplace-blockchain.md
+++ b/curriculum/locales/english/build-a-video-game-marketplace-blockchain.md
@@ -377,7 +377,7 @@ Running `node buy-item.js <address-privateKey> <item>` should not add a transact
 
 ```js
 // test 8
-const testFolder = `${testsFolder}/test7`;
+const testFolder = `${testsFolder}/test8`;
 await __helpers.copyProjectFiles(projectFolder, testFolder, projectFiles);
 await __helpers.runCommand('node init-blockchain.js', testFolder);
 await __helpers.runCommand('node generate-wallet.js user_xyz123', testFolder);


### PR DESCRIPTION
Fixed the issue that test 8 in the marketplace tutorial never passes. It was caused by the code mistype of test7 instead of test8 where the 8th test runs in the 7th folder which contains the blockchain and transactions data of the 7th test. That led to the incorrect number of transactions being interpreted during test 8.
The fix was to change the folder name in the js script that runs the test.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #88

<!-- Feel free to add any additional description of changes below this line -->
