### PR TITLE
Fix (tools/scripts): parser regex

### DIFF
--- a/.freeCodeCamp/tooling/parser.js
+++ b/.freeCodeCamp/tooling/parser.js
@@ -89,7 +89,7 @@ export function getLessonDescription(lesson) {
 export function getLessonHintsAndTests(lesson) {
   const testsString = parseMarker(TEST_MARKER, lesson);
   const hintsAndTestsArr = [];
-  const hints = testsString?.match(/^(.*?)$(?=\r?\n+```js)/gm)?.filter(Boolean);
+  const hints = testsString?.match(/^(.*?)$(?=\r?\n+```js)/gms)?.filter(Boolean);
   const tests = testsString?.match(/(?<=```js\r?\n).*?(?=```)/gms);
 
   if (hints?.length) {

--- a/.freeCodeCamp/tooling/parser.js
+++ b/.freeCodeCamp/tooling/parser.js
@@ -10,7 +10,7 @@ const SEED_MARKER = '### --seed--';
 const BEFORE_ALL_MARKER = '### --before-all--';
 const AFTER_ALL_MARKER = '### --after-all--';
 const BEFORE_EACH_MARKER = '### --before-each--';
-const NEXT_MARKER_REG = `\n###? --`;
+const NEXT_MARKER_REG = `\r?\n###? --`;
 const CMD_MARKER = '#### --cmd--';
 const FILE_MARKER_REG = '(?<=#### --")[^"]+(?="--)';
 
@@ -59,7 +59,7 @@ export async function getLessonFromFile(file, lessonNumber = 1) {
   const fileContent = await readFile(file, 'utf8');
   const mat = fileContent.match(
     new RegExp(
-      `## ${lessonNumber}\n(.*?)\n## (${lessonNumber + 1}|--fcc-end--)`,
+      `## ${lessonNumber}\r?\n(.*?)\r?\n## (${lessonNumber + 1}|--fcc-end--)`,
       's'
     )
   );
@@ -89,8 +89,8 @@ export function getLessonDescription(lesson) {
 export function getLessonHintsAndTests(lesson) {
   const testsString = parseMarker(TEST_MARKER, lesson);
   const hintsAndTestsArr = [];
-  const hints = testsString?.match(/^(.*?)$(?=\n+```js)/gm)?.filter(Boolean);
-  const tests = testsString?.match(/(?<=```js\n).*?(?=```)/gms);
+  const hints = testsString?.match(/^(.*?)$(?=\r?\n+```js)/gm)?.filter(Boolean);
+  const tests = testsString?.match(/(?<=```js\r?\n).*?(?=```)/gms);
 
   if (hints?.length) {
     for (let i = 0; i < hints.length; i++) {
@@ -152,7 +152,7 @@ export function getAfterAll(lesson) {
  * @returns {string[]} The commands of the lesson in order
  */
 export function getCommands(seed) {
-  const cmds = seed.match(new RegExp(`${CMD_MARKER}\n(.*?\`\`\`\n)`, 'gs'));
+  const cmds = seed.match(new RegExp(`${CMD_MARKER}\r?\n(.*?\`\`\`\r?\n)`, 'gs'));
   const commands = cmds?.map(cmd => extractStringFromCode(cmd)?.trim());
   return commands ?? [];
 }
@@ -164,7 +164,7 @@ export function getCommands(seed) {
  */
 export function getFilesWithSeed(seed) {
   const files = seed.match(
-    new RegExp(`#### --"([^"]+)"--\n(.*?\`\`\`\n)`, 'gs')
+    new RegExp(`#### --"([^"]+)"--\r?\n(.*?\`\`\`\r?\n)`, 'gs')
   );
   const filePaths = seed.match(new RegExp(FILE_MARKER_REG, 'gsm'));
   const fileSeeds = files?.map(file => extractStringFromCode(file)?.trim());
@@ -193,7 +193,7 @@ export function isForceFlag(seed) {
  * @returns {string} The stripped codeblock
  */
 export function extractStringFromCode(code) {
-  return code.replace(/.*?```[a-z]+\n(.*?)```.*/s, '$1');
+  return code.replace(/.*?```[a-z]+\r?\n(.*?)```.*/s, '$1');
 }
 
 /**
@@ -216,7 +216,7 @@ export async function getTotalLessons(file) {
  */
 function parseMarker(marker, lesson) {
   const mat = lesson.match(
-    new RegExp(`${marker}\n(((?!${NEXT_MARKER_REG}).)*\n?)`, 's')
+    new RegExp(`${marker}\r?\n(((?!${NEXT_MARKER_REG}).)*\r?\n?)`, 's')
   );
   return mat?.[1];
 }
@@ -226,12 +226,12 @@ function parseMarker(marker, lesson) {
  * @param {string} seed The lesson seed
  */
 export function* seedToIterator(seed) {
-  const sections = seed.match(new RegExp(`#### --(((?!#### --).)*\n?)`, 'sg'));
+  const sections = seed.match(new RegExp(`#### --(((?!#### --).)*\r?\n?)`, 'sg'));
   for (const section of sections) {
     const isFile = section.match(
-      new RegExp(`#### --"([^"]+)"--\n(.*?\`\`\`\n)`, 's')
+      new RegExp(`#### --"([^"]+)"--\r?\n(.*?\`\`\`\r?\n)`, 's')
     );
-    const isCMD = section.match(new RegExp(`#### --cmd--\n(.*?\`\`\`\n)`, 's'));
+    const isCMD = section.match(new RegExp(`#### --cmd--\r?\n(.*?\`\`\`\r?\n)`, 's'));
     if (isFile) {
       const filePath = isFile[1];
       const fileSeed = extractStringFromCode(isFile[2])?.trim();


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Closes #87

<!-- Feel free to add any additional description of changes below this line -->

For some reason after I started container on a local machine all .md files have windows' style eof (\r\n). So I suggest to use \r?\n for new lines in parser.js for more compatibility. 

I also had to add **s** flag for hint's regex. Otherwise it can't parse multiline hints and I can't see tests in my browser.

I've tested these fixes manually on a local machine. Unfortunately automative tests (npm run test) does not work.