### PR TITLE
fix: allow comma after last property

### DIFF
--- a/curriculum/locales/english/learn-digital-ledgers-by-building-a-blockchain.md
+++ b/curriculum/locales/english/learn-digital-ledgers-by-building-a-blockchain.md
@@ -1969,7 +1969,7 @@ You should have `fromAddress: process.argv[2]` in your `data` object
 ```js
 await new Promise(res => setTimeout(res, 1000));
 const fileContents = await __helpers.getFile('learn-digital-ledgers-by-building-a-blockchain/add-block.js');
-assert.match(fileContents, /newBlock[\s\S]*data[\s\S]*{\s*(|"|')fromAddress\1\s*:\s*process\s*\.argv\s*\[\s*2\s*]\s*,?\s*}\s*,?[\s\S*]}/);
+assert.match(fileContents, /newBlock[\s\S]*data[\s\S]*{\s*(|"|')fromAddress\1\s*:\s*process\s*\.argv\s*\[\s*2\s*]\s*,?\s*}[\s\S]*}/);
 ```
 
 ### --seed--

--- a/curriculum/locales/english/learn-digital-ledgers-by-building-a-blockchain.md
+++ b/curriculum/locales/english/learn-digital-ledgers-by-building-a-blockchain.md
@@ -1969,7 +1969,7 @@ You should have `fromAddress: process.argv[2]` in your `data` object
 ```js
 await new Promise(res => setTimeout(res, 1000));
 const fileContents = await __helpers.getFile('learn-digital-ledgers-by-building-a-blockchain/add-block.js');
-assert.match(fileContents, /newBlock[\s\S]*data[\s\S]*{\s*(|"|')fromAddress\1\s*:\s*process\s*\.argv\s*\[\s*2\s*]\s*,?\s*}[\s\S*]}/);
+assert.match(fileContents, /newBlock[\s\S]*data[\s\S]*{\s*(|"|')fromAddress\1\s*:\s*process\s*\.argv\s*\[\s*2\s*]\s*,?\s*}\s*,?[\s\S*]}/);
 ```
 
 ### --seed--


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

---
- Allows optional comma after the `data` property. Two further lessons, adding more to the `data`, are already fine with the comma.
- Before change, passing:
```
const newBlock = {
  hash: Math.random().toString(),
  previousHash: previousBlock.hash,
  data: {
    fromAddress: process.argv[2],
  }
}
```
- Before change, not passing:
```
const newBlock = {
  hash: Math.random().toString(),
  previousHash: previousBlock.hash,
  data: {
    fromAddress: process.argv[2],
  },
}
```
- After change both passes.
