### PR TITLE
fix: description and hint text

### DIFF
--- a/curriculum/locales/english/learn-digital-ledgers-by-building-a-blockchain.md
+++ b/curriculum/locales/english/learn-digital-ledgers-by-building-a-blockchain.md
@@ -1646,7 +1646,7 @@ Open your new `validate-chain.js` file and import the `isValidChain` function yo
 
 ### --tests--
 
-You should have `import { isValidChain } from 'blockchain-helpers.js'` at the top of your `validate-chain.js` file
+You should have `import { isValidChain } from './blockchain-helpers.js'` at the top of your `validate-chain.js` file
 
 ```js
 await new Promise(res => setTimeout(res, 1000));
@@ -2609,7 +2609,7 @@ assert.match(lastOutput, /Chain is valid/);
 
 ### --description--
 
-Transactions aren't stored usually stored on the blockchain right away, they go into a waiting area known as a transaction pool until a new block is added. You will create this next. In your `blockchain-helpers.js` export a new `writeTransactions` function. Give it a parameter of `transactions` and leave the function empty to start.
+Transactions aren't usually stored on the blockchain right away – they go into a waiting area known as a transaction pool until a new block is added. You will create this next. In your `blockchain-helpers.js` export a new `writeTransactions` function. Give it a parameter of `transactions` and leave the function empty to start.
 
 ### --tests--
 
@@ -2793,7 +2793,7 @@ At the top of your new file, import the `writeTransactions` function you created
 
 ### --tests--
 
-You should have `import { writeTransactions } from 'blockchain-helpers.js';` in your `add-transaction.js` file
+You should have `import { writeTransactions } from './blockchain-helpers.js';` in your `add-transaction.js` file
 
 ```js
 await new Promise(res => setTimeout(res, 1000));

--- a/curriculum/locales/english/learn-proof-of-work-consensus-by-building-a-block-mining-algorithm.md
+++ b/curriculum/locales/english/learn-proof-of-work-consensus-by-building-a-block-mining-algorithm.md
@@ -1366,7 +1366,7 @@ writeTransactions([]);
 
 ### --description--
 
-You want your `hash` to start with a zero. Create a `while` loop that checks if `!hash.startsWith('0')` and put your `console.log` in the loop.
+You want your `hash` to start with a zero. Create a `while` loop that checks if `!hash.startsWith('0')`. Also, move your `console.log` statement that logs the value of `hash` into the loop.
 
 ### --tests--
 
@@ -5740,7 +5740,7 @@ assert.match(lastOutput, /Chain is valid/);
 
 ### --description--
 
-There's one more thing to do here, make it so you can't send transactions unless you have enough tokens. In the `blockchain-helpers.js` file, export a new `getAddressBalance` function. Have it accept an `address` parameter, and leave the function empty for now.
+There's one more thing to do here: Make it so you can't send transactions unless you have enough tokens. In the `blockchain-helpers.js` file, export a new `getAddressBalance` function. Have it accept an `address` parameter, and leave the function empty for now.
 
 ### --tests--
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
These are just minor tweaks to the description and hint text for some challenges I noticed while going through the first two Web3 projects.

Here's a quick summary of the changes:

**Learn Digital Ledgers By Building a Blockchain Steps**:
- Step 49: The hint suggests `import  { isValidChain } from 'blockchain-helpers.js'`, but the test requires `import  { isValidChain } from './blockchain-helpers.js';`.
- Step 70: "Transactions aren't stored usually stored on the blockchain right away, they go into a waiting area known as a transaction pool until a new block is added." --> "Transactions aren't usually stored on the blockchain right away – they go into a waiting area known as a transaction pool until a new block is added."
- Step: 74: Similar issue as step 49 where `import { writeTransactions } from "blockchain-helpers.js";` is shown in the hint, but the test requires `import { writeTransactions } from "./blockchain-helpers.js";`.

**Learn Proof of Work Consensus by Building a Block Mining Algorithm Steps**:
- Step 25: This was probably user error on my part because I probably removed the `console.log(hash)` line earlier than I should have, and was a bit lost when I got to this step. Still, I thought it wouldn't hurt to be a bit more specific in case other learners do the same thing.
- Step 96: "There's one more thing to do here, make it so you can't send transactions unless you have enough tokens." --> "There's one more thing to do here: Make it so you can't send transactions unless you have enough tokens."